### PR TITLE
Always run the robot state publisher

### DIFF
--- a/launch/hdt_7dof_rviz.launch
+++ b/launch/hdt_7dof_rviz.launch
@@ -3,14 +3,14 @@
 	<!-- arguments -->
 	<arg name="arm" default="left" />
 	<arg name="gui" default="true" />
-	<arg name="publish_states" default="false" />
+	<arg name="publish_joint_states" default="false" />
 	
 	<!-- load urdf -->
 	<param name="robot_description" command="$(find xacro)/xacro.py '$(find hdt_7dof_description)/urdf/hdt_7dof_$(arg arm).xacro'"/>
 	
 	<!-- optionally start state publishers -->
-	<node if="$(arg publish_states)" name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
-	<node if="$(arg publish_states)" name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+	<node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+	<node if="$(arg publish_joint_states)" name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
 		<param name="use_gui" value="$(arg gui)" />
 	</node>
 	


### PR DESCRIPTION
You always need one running, and they're all the same anyway. If
the old one quits it's not a bad thing. I think something else
in the system used to run it but no longer does, so add it back
here.
