### PR TITLE
Added bbox model of hdt arms

### DIFF
--- a/urdf/hdt_7dof_hand_bbox.xacro
+++ b/urdf/hdt_7dof_hand_bbox.xacro
@@ -1,0 +1,326 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="hdt_7dof_hand_bbox">
+    <!-- default inertia -->
+    <xacro:macro name="default_inertial">
+        <inertial>
+            <mass value="0.025"/>
+            <inertia
+                ixx="0.0005" ixy="0.0" ixz="0.0"
+                iyy="0.0005" iyz="0.0"
+                izz="0.0005"/>
+        </inertial>
+    </xacro:macro>
+    <xacro:macro name="hdt_7dof_hand_bbox" params="prefix reflect motor_base_id left_only right_only">
+        <link name="${prefix}palm">
+            <collision>
+                <origin xyz="0 -0.08 0" rpy="0 0 1.57079633"/>
+                <geometry>
+                    <box size="0.17 0.055 0.1"/>
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="0 -0.08 0" rpy="0 0 1.57079633"/>
+                <geometry>
+                    <box size="0.17 0.055 0.1"/>
+                </geometry>
+                <material name="${prefix}black"/>
+            </visual>
+            <inertial>
+                <origin xyz="0 -0.08326 -0.00539" rpy="0 0 0"/>
+                <mass value="0.56756"/>
+                <inertia
+                    ixx="0.001727803" ixy="0.000001205" ixz="0.0"
+                    iyy="0.000549457" iyz="-0.000101997"
+                    izz="0.001418031"/>
+            </inertial>
+        </link>
+
+        <!-- gripper frame -->
+        <joint name="${prefix}gripper_frame_joint" type="fixed">
+            <origin xyz="0 -0.13 0" rpy="0 0 -1.57079" />
+            <parent link="${prefix}palm" />
+            <child link="${prefix}gripper_frame" />
+        </joint>
+
+        <link name="${prefix}gripper_frame" />
+
+        <!-- Hacked in joint to match ViGIR frames -->
+        <joint name="${prefix}vigir_joint" type="fixed">
+            <origin xyz = "0 -0.13 0" rpy="0 0 0" />
+            <parent link="${prefix}palm" />
+            <child link="${prefix}hand" />
+        </joint>
+
+        <link name="${prefix}hand" />
+
+        <!-- thumb base -->
+        <joint name="${prefix}thumb_roll" type="revolute">
+            <hdt id="${motor_base_id + 9}" kmin="5" kmax="20" inertia="0.01"/>
+            <axis xyz="0 -1 0"/>
+            <limit effort="4.0" lower="-1.5708" upper="1.5708" velocity="4.1888"/>
+            <origin xyz="0 -0.05039 0.01529" rpy="0 0 0"/>
+            <parent link="${prefix}palm"/>
+            <child link="${prefix}thumb_base"/>
+            <dynamics damping="0.7" friction="0.0"/>
+        </joint>
+
+        <transmission name="${prefix}tran10">
+            <type>transmission_interface/SimpleTransmission</type>
+            <joint name="${prefix}thumb_roll">
+            </joint>
+            <actuator name="${prefix}motor10">
+                <hardwareInterface>EffortJointInterface</hardwareInterface>
+                <mechanicalReduction>1</mechanicalReduction>
+            </actuator>
+        </transmission>
+
+        <link name="${prefix}thumb_base">
+            <collision>
+                <origin xyz="0 -0.025 0.0075" rpy="0 0 1.57079633"/>
+                <geometry>
+                    <box size="0.05 0.05 0.08"/>
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="0 -0.025 0.0075" rpy="0 0 1.57079633"/>
+                <geometry>
+                    <box size="0.05 0.05 0.08"/>
+                </geometry>
+                <material name="${prefix}grey"/>
+            </visual>
+            <inertial>
+                <origin xyz="0 -0.02653 0.02207" rpy="0 0 0"/>
+                <mass value="0.08562"/>
+                <inertia
+                    ixx="0.0000315" ixy="0.0" ixz="0.0"
+                    iyy="0.000034299" iyz="0.0"
+                    izz="0.000022344"/>
+            </inertial>
+        </link>
+
+        <!-- thumb prox -->
+        <joint name="${prefix}thumb_pitch" type="revolute">
+            <hdt id="${motor_base_id + 10}" kmin="5" kmax="20" inertia="0.01"/>
+            <axis xyz="1 0 0"/>
+            <limit effort="4.0" lower="-0.7854" upper="1.5708" velocity="4.1888"/>
+            <origin xyz="0.00214 -0.02759 0.05700" rpy="0 0 0"/>
+            <parent link="${prefix}thumb_base"/>
+            <child link="${prefix}thumb_prox"/>
+            <dynamics damping="0.7" friction="0.0"/>
+        </joint>
+
+        <transmission name="${prefix}tran11">
+            <type>transmission_interface/SimpleTransmission</type>
+            <joint name="${prefix}thumb_pitch">
+            </joint>
+            <actuator name="${prefix}motor11">
+                <hardwareInterface>EffortJointInterface</hardwareInterface>
+                <mechanicalReduction>1</mechanicalReduction>
+            </actuator>
+        </transmission>
+
+        <link name="${prefix}thumb_prox">
+            <collision>
+                <origin xyz="0 0 0.05" rpy="0 0 0"/>
+                <geometry>
+                    <cylinder length="0.12" radius="0.02"/>
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="0 0 0.05" rpy="0 0 0"/>
+                <geometry>
+                    <cylinder length="0.12" radius="0.02"/>
+                </geometry>
+                <material name="${prefix}grey"/>
+            </visual>
+            <xacro:default_inertial/>
+        </link>
+        <gazebo reference="${prefix}thumb_prox">
+            <material>Gazebo/Grey</material>
+        </gazebo>
+
+        <!-- thumb med -->
+        <joint name="${prefix}thumb_med" type="fixed">
+            <origin xyz="0 0.00285 0.04341" rpy="0 0 0"/>
+            <parent link="${prefix}thumb_prox"/>
+            <child link="${prefix}thumb_med"/>
+        </joint>
+
+        <link name="${prefix}thumb_med">
+            <inertial>
+                <origin xyz="0 -0.00353 0.01162" rpy="0 0 0"/>
+                <mass value="0.0085"/>
+                <inertia
+                    ixx="0.000001099" ixy="0.0" ixz="0.0"
+                    iyy="0.000001639" iyz="0.000000096"
+                    izz="0.000000981"/>
+            </inertial>
+        </link>
+
+        <!-- thumb dist -->
+        <joint name="${prefix}thumb_dist" type="fixed">
+            <origin xyz="0 -0.0009 0.02769" rpy="0 0 0"/>
+            <parent link="${prefix}thumb_med"/>
+            <child link="${prefix}thumb_dist"/>
+        </joint>
+
+        <link name="${prefix}thumb_dist">
+            <inertial>
+                <origin xyz="0 -0.00131 0.01323" rpy="0 0 0"/>
+                <mass value="0.0092"/>
+                <inertia
+                    ixx="0.00000066" ixy="0.0" ixz="0.0"
+                    iyy="0.000000837" iyz="0.0"
+                    izz="0.000000695"/>
+            </inertial>
+        </link>
+
+        <!-- index prox -->
+        <joint name="${prefix}index_yaw" type="revolute">
+            <hdt id="${motor_base_id + 11}" kmin="5" kmax="20" inertia="0.01"/>
+            <axis xyz="0 0 ${reflect*-1}"/>
+            <limit effort="4.0" lower="${left_only*-1.5708 + right_only*-0.7854}" upper="${left_only*0.7854 + right_only*1.5708}" velocity="4.1888"/>
+            <origin xyz="0 -0.16325 0.02701" rpy="0 ${left_only*3.1416} 0"/>
+            <parent link="${prefix}palm"/>
+            <child link="${prefix}index_prox"/>
+            <dynamics damping="0.7" friction="0.0"/>
+        </joint>
+
+        <transmission name="${prefix}tran12">
+            <type>transmission_interface/SimpleTransmission</type>
+            <joint name="${prefix}index_yaw">
+            </joint>
+            <actuator name="${prefix}motor12">
+                <hardwareInterface>EffortJointInterface</hardwareInterface>
+                <mechanicalReduction>1</mechanicalReduction>
+            </actuator>
+        </transmission>
+
+        <link name="${prefix}index_prox">
+            <collision>
+                <origin xyz="0 -0.05 0" rpy="-1.57079633 0 0"/>
+                <geometry>
+                    <cylinder length="0.12" radius="0.02"/>
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="0 -0.05 0" rpy="-1.57079633 0 0"/>
+                <geometry>
+                    <cylinder length="0.12" radius="0.02"/>
+                </geometry>
+                <material name="${prefix}grey"/>
+            </visual>
+            <xacro:default_inertial/>
+        </link>
+
+        <!-- index med -->
+        <joint name="${prefix}index_med" type="fixed">
+            <origin xyz="-0.00285 -0.04341 0" rpy="0 0 0"/>
+            <parent link="${prefix}index_prox"/>
+            <child link="${prefix}index_med"/>
+        </joint>
+
+        <link name="${prefix}index_med">
+            <inertial>
+                <origin xyz="0.00353 -0.01162 0" rpy="0 0 0"/>
+                <mass value="0.0085"/>
+                <inertia
+                    ixx="0.000001639" ixy="0.000000096" ixz="0.0"
+                    iyy="0.000000981" iyz="0.0"
+                    izz="0.000001099"/>
+            </inertial>
+        </link>
+
+        <!-- index dist -->
+        <joint name="${prefix}index_dist" type="fixed">
+            <origin xyz="0.0009 -0.02769 0" rpy="0 0 0"/>
+            <parent link="${prefix}index_med"/>
+            <child link="${prefix}index_dist"/>
+        </joint>
+
+        <link name="${prefix}index_dist">
+            <inertial>
+                <origin xyz="0.00131 -0.01323 0" rpy="0 0 0"/>
+                <mass value="0.0092"/>
+                <inertia
+                    ixx="0.000000837" ixy="0.0" ixz="0.0"
+                    iyy="0.000000695" iyz="0.0"
+                    izz="0.00000066"/>
+            </inertial>
+        </link>
+
+        <!-- ring prox -->
+        <joint name="${prefix}ring_yaw" type="revolute">
+            <hdt id="${motor_base_id + 12}" kmin="5" kmax="20" inertia="0.01"/>
+            <axis xyz="0 0 ${reflect*-1}"/>
+            <limit effort="4.0" lower="${left_only*-1.5708 + right_only*-0.7854}" upper="${left_only*0.7854 + right_only*1.5708}" velocity="4.1888"/>
+            <origin xyz="0 -0.16325 -0.02701" rpy="0 ${left_only*3.1416} 0"/>
+            <parent link="${prefix}palm"/>
+            <child link="${prefix}ring_prox"/>
+            <dynamics damping="0.7" friction="0.0"/>
+        </joint>
+
+        <transmission name="${prefix}tran13">
+            <type>transmission_interface/SimpleTransmission</type>
+            <joint name="${prefix}ring_yaw">
+            </joint>
+            <actuator name="${prefix}motor13">
+                <hardwareInterface>EffortJointInterface</hardwareInterface>
+                <mechanicalReduction>1</mechanicalReduction>
+            </actuator>
+        </transmission>
+
+        <link name="${prefix}ring_prox">
+            <collision>
+                <origin xyz="0 -0.05 0" rpy="-1.57079633 0 0"/>
+                <geometry>
+                    <cylinder length="0.12" radius="0.02"/>
+                </geometry>
+            </collision>
+            <visual>
+                <origin xyz="0 -0.05 0" rpy="-1.57079633 0 0"/>
+                <geometry>
+                    <cylinder length="0.12" radius="0.02"/>
+                </geometry>
+                <material name="${prefix}grey"/>
+            </visual>
+            <xacro:default_inertial/>
+        </link>
+
+        <!-- ring med -->
+        <joint name="${prefix}ring_med" type="fixed">
+            <origin xyz="-0.00285 -0.04341 0" rpy="0 0 0"/>
+            <parent link="${prefix}ring_prox"/>
+            <child link="${prefix}ring_med"/>
+        </joint>
+
+        <link name="${prefix}ring_med">
+            <inertial>
+                <origin xyz="0.00353 -0.01162 0" rpy="0 0 0"/>
+                <mass value="0.0085"/>
+                <inertia
+                    ixx="0.000001639" ixy="0.000000096" ixz="0.0"
+                    iyy="0.000000981" iyz="0.0"
+                    izz="0.000001099"/>
+            </inertial>
+        </link>
+
+        <!-- ring dist -->
+        <joint name="${prefix}ring_dist" type="fixed">
+            <origin xyz="0.0009 -0.02769 0" rpy="0 0 0"/>
+            <parent link="${prefix}ring_med"/>
+            <child link="${prefix}ring_dist"/>
+        </joint>
+
+        <link name="${prefix}ring_dist">
+            <inertial>
+                <origin xyz="0.00131 -0.01323 0" rpy="0 0 0"/>
+                <mass value="0.0092"/>
+                <inertia
+                    ixx="0.000000837" ixy="0.0" ixz="0.0"
+                    iyy="0.000000695" iyz="0.0"
+                    izz="0.00000066"/>
+            </inertial>
+        </link>
+    </xacro:macro>
+</robot>

--- a/urdf/hdt_7dof_macro_bbox.xacro
+++ b/urdf/hdt_7dof_macro_bbox.xacro
@@ -1,0 +1,383 @@
+<?xml version="1.0"?>
+<robot name="hdt_7dof" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+	<xacro:macro name="hdt_7dof_left" params="prefix parent x y z motor_base_id">
+		<xacro:hdt_7dof reflect="1" left_only="1" right_only="0" prefix="${prefix}" parent="${parent}" x="${x}" y="${y}" z="${z}" yaw="-1.57079" motor_base_id="${motor_base_id}"/>
+	</xacro:macro>
+	<xacro:macro name="hdt_7dof_right" params="prefix parent x y z motor_base_id">
+		<xacro:hdt_7dof reflect="-1" left_only="0" right_only="1" prefix="${prefix}" parent="${parent}" x="${x}" y="${y}" z="${z}" yaw="1.57079" motor_base_id="${motor_base_id}"/>
+	</xacro:macro>
+
+	<!-- hand included here -->
+	<xacro:include filename="$(find hdt_7dof_description)/urdf/hdt_7dof_hand_bbox.xacro" />
+
+	<!-- reflect: should be either 1 or -1, and can be multiplied to negate a side -->
+	<!--          the left:1, right:-1 mapping is the same as for PR2 (and works with the standard y axis) -->
+	<!-- left_only and right_only: will be either 0 or 1, and can be multplied for side-dependent results -->
+	<!-- unfortunately, xacro limitations prohibit calculating any of these values from the others, so they must all be passed in -->
+	<xacro:macro name="hdt_7dof" params="prefix reflect left_only right_only parent x y z yaw motor_base_id">
+
+		<!-- materials -->
+		<material name="${prefix}green">
+			<color rgba="${53/255} ${94/255} ${59/255} 1.0"/>
+		</material>
+
+		<material name="${prefix}black">
+			<color rgba="${0/255} ${0/255} ${0/255} 1.0"/>
+		</material>
+
+		<material name="${prefix}grey">
+			<color rgba="${40/255} ${40/255} ${40/255} 1.0"/>
+		</material>
+
+		<!-- shoulder -->
+		<joint name="${prefix}shoulder_pitch" type="revolute">
+			<hdt id="${motor_base_id + 0}" kmin="100" kmax="200" inertia="0.1"/>
+			<axis xyz="${reflect*-1} 0 0"/>
+			<limit effort="60.0" lower="-3.1416" upper="1.0472" velocity="2.0944"/>
+			<origin xyz="${x} ${y} ${z}" rpy="0 0 ${yaw}"/>
+			<parent link="${parent}"/>
+			<child link="${prefix}shoulder"/>
+			<dynamics damping="0.7" friction="0.0"/>
+		</joint>
+
+		<transmission name="${prefix}tran1">
+			<type>transmission_interface/SimpleTransmission</type>
+			<joint name="${prefix}shoulder_pitch">
+			</joint>
+			<actuator name="${prefix}motor1">
+				<hardwareInterface>EffortJointInterface</hardwareInterface>
+				<mechanicalReduction>1</mechanicalReduction>
+			</actuator>
+		</transmission>
+
+		<link name="${prefix}shoulder">
+			<inertial>
+				<origin xyz="-0.04488 0 0" rpy="0 0 0"/>
+				<mass value="1.00775"/>
+				<inertia
+					ixx="0.00064952" ixy="0.0" ixz="0.0"
+					iyy="0.00104342" iyz="0.0"
+					izz="0.00104342"/>
+			</inertial>
+		</link>
+
+		<joint name="${prefix}shoulder_fixed" type="fixed">
+			<parent link="${prefix}shoulder"/>
+			<child link="${prefix}shoulder_roll_bracket"/>
+			<origin xyz="-0.09217 0 0" rpy="0 0 0"/>
+		</joint>
+
+		<link name="${prefix}shoulder_roll_bracket">
+			<collision>
+				<origin xyz="0 0 0" rpy="0 1.57079633 0"/>
+				<geometry>
+				  <cylinder length="0.2" radius="0.05" />
+				</geometry>
+			</collision>
+			<visual>
+				<origin xyz="0 0 0" rpy="0 1.57079633 0"/>
+				<geometry>
+					<cylinder length="0.2" radius="0.05" />
+				</geometry>
+				<material name="${prefix}green"/>
+			</visual>
+			<inertial>
+				<origin xyz="-0.04416876 0 0" rpy="0 0 0"/>
+				<mass value="0.66774822"/>
+				<inertia
+					ixx="0.00062987" ixy="0.0" ixz="0.0"
+					iyy="0.00091291" iyz="0.0"
+					izz="0.00110241"/>
+			</inertial>
+		</link>
+
+		<!-- shoulder roll -->
+		<joint name="${prefix}shoulder_roll" type="revolute">
+			<hdt id="${motor_base_id + 1}" kmin="100" kmax="200" inertia="0.1"/>
+			<axis xyz="0 ${reflect*1} 0"/>
+			<limit effort="60.0" lower="${left_only*-0.5236 + right_only*-3.1416}" upper="${left_only*3.1416 + right_only*0.5236}" velocity="2.0944"/>
+			<origin xyz="-0.07 0 0" rpy="0 0 0"/>
+			<parent link="${prefix}shoulder_roll_bracket"/>
+			<child link="${prefix}shoulder_roll_motor"/>
+			<dynamics damping="0.7" friction="0.0"/>
+		</joint>
+
+		<transmission name="${prefix}tran2">
+			<type>transmission_interface/SimpleTransmission</type>
+			<joint name="${prefix}shoulder_roll">
+			</joint>
+			<actuator name="${prefix}motor2">
+				<hardwareInterface>EffortJointInterface</hardwareInterface>
+				<mechanicalReduction>1</mechanicalReduction>
+			</actuator>
+		</transmission>
+
+		<link name="${prefix}shoulder_roll_motor">
+			<collision>
+				<origin xyz="0 0 -0.16" rpy="0 0 0"/>
+				<geometry>
+					<cylinder length="0.32" radius="0.05"/>
+				</geometry>
+			</collision>
+			<visual>
+				<origin xyz="0 0 -0.16" rpy="0 0 0"/>
+				<geometry>
+					<cylinder length="0.32" radius="0.05"/>
+				</geometry>
+				<material name="${prefix}green"/>
+			</visual>
+			<inertial>
+				<origin xyz="0 0 -0.02018105" rpy="0 0 0"/>
+				<mass value="0.69896"/>
+				<inertia
+					ixx="0.00088116" ixy="0.0" ixz="0.0"
+					iyy="0.00094182" iyz="0.0"
+					izz="0.00032992"/>
+			</inertial>
+		</link>
+
+		<!-- upper arm -->
+		<joint name="${prefix}shoulder_yaw" type="revolute">
+			<hdt id="${motor_base_id + 2}" kmin="75" kmax="150" inertia="0.075"/>
+			<axis xyz="0 0 1"/>
+			<limit effort="60.0" lower="-2.0944" upper="2.0944" velocity="2.0944"/>
+			<origin xyz="0 0 -0.077" rpy="0 0 0" />
+			<parent link="${prefix}shoulder_roll_motor"/>
+			<child link="${prefix}upper_arm"/>
+			<dynamics damping="0.7" friction="0.0"/>
+		</joint>
+
+		<transmission name="${prefix}tran3">
+			<type>transmission_interface/SimpleTransmission</type>
+			<joint name="${prefix}shoulder_yaw">
+			</joint>
+			<actuator name="${prefix}motor3">
+				<hardwareInterface>EffortJointInterface</hardwareInterface>
+				<mechanicalReduction>1</mechanicalReduction>
+			</actuator>
+		</transmission>
+
+		<link name="${prefix}upper_arm">
+			<inertial>
+				<origin xyz="0 0 -0.08013953" rpy="0 0 0"/>
+				<mass value="1.77733729"/>
+				<inertia
+					ixx="0.00450640" ixy="0.0" ixz="0.0"
+					iyy="0.00450640" iyz="0.0"
+					izz="0.00114447"/>
+			</inertial>
+		</link>
+
+		<joint name="${prefix}upper_arm_fixed" type="fixed">
+			<origin xyz="0 0 -0.16271" rpy="0 0 0"/>
+			<parent link="${prefix}upper_arm"/>
+			<child link="${prefix}elbow_pitch_bracket"/>
+		</joint>
+
+		<link name="${prefix}elbow_pitch_bracket">
+			<inertial>
+				<origin xyz="0 0 -0.04416876" rpy="0 0 0"/>
+				<mass value="0.66774822"/>
+				<inertia
+					ixx="0.00091291" ixy="0.0" ixz="0.0"
+					iyy="0.00110241" iyz="0.0"
+					izz="0.00062987"/>
+			</inertial>
+		</link>
+
+		<!-- elbow pitch -->
+		<joint name="${prefix}elbow_pitch" type="revolute">
+			<hdt id="${motor_base_id + 3}" kmin="75" kmax="150" inertia="0.075"/>
+			<axis xyz="${reflect*-1} 0 0"/>
+			<limit effort="60.0" lower="-0.5236" upper="3.6652" velocity="2.0944"/>
+			<origin xyz="0 0 -0.07" rpy="${left_only*3.1416} 0 0"/>
+			<parent link="${prefix}elbow_pitch_bracket"/>
+			<child link="${prefix}elbow_pitch_motor"/>
+			<dynamics damping="0.7" friction="0.0"/>
+		</joint>
+
+		<transmission name="${prefix}tran4">
+			<type>transmission_interface/SimpleTransmission</type>
+			<joint name="${prefix}elbow_pitch">
+			</joint>
+			<actuator name="${prefix}motor4">
+				<hardwareInterface>EffortJointInterface</hardwareInterface>
+				<mechanicalReduction>1</mechanicalReduction>
+			</actuator>
+		</transmission>
+
+		<link name="${prefix}elbow_pitch_motor">
+			<collision>
+				<origin xyz="0 -0.1 0" rpy="1.57079633 0 0"/>
+				<geometry>
+					<cylinder length="0.2" radius="0.05"/>
+				</geometry>
+			</collision>
+			<visual>
+				<origin xyz="0 -0.1 0" rpy="1.57079633 0 0"/>
+				<geometry>
+					<cylinder length="0.2" radius="0.05"/>
+				</geometry>
+				<material name="${prefix}green"/>
+			</visual>
+			<inertial>
+				<origin xyz="0 -0.02018105 0" rpy="0 0 0"/>
+				<mass value="0.69896279"/>
+				<inertia
+					ixx="0.00094182" ixy="0.0" ixz="0.0"
+					iyy="0.00032992" iyz="0.0"
+					izz="0.00088116"/>
+			</inertial>
+		</link>
+
+		<!-- forearm -->
+		<joint name="${prefix}elbow_roll" type="revolute">
+			<hdt id="${motor_base_id + 4}" kmin="50" kmax="100" inertia="0.05"/>
+			<axis xyz="0 -1 0"/>
+			<limit effort="60.0" lower="-2.0944" upper="2.0944" velocity="2.0944"/>
+			<origin xyz="0 -0.077 0" rpy="0 ${left_only*3.1416} 0"/>
+			<parent link="${prefix}elbow_pitch_motor"/>
+			<child link="${prefix}forearm"/>
+			<dynamics damping="0.7" friction="0.0"/>
+		</joint>
+
+		<transmission name="${prefix}tran5">
+			<type>transmission_interface/SimpleTransmission</type>
+			<joint name="${prefix}elbow_roll">
+			</joint>
+			<actuator name="${prefix}motor5">
+				<hardwareInterface>EffortJointInterface</hardwareInterface>
+				<mechanicalReduction>1</mechanicalReduction>
+			</actuator>
+		</transmission>
+
+		<link name="${prefix}forearm">
+			<inertial>
+				<origin xyz="0 -0.04487724 0" rpy="0 0 0"/>
+				<mass value="1.00775488"/>
+				<inertia
+					ixx="0.00104342" ixy="0.0" ixz="0.0"
+					iyy="0.00064952" iyz="0.0"
+					izz="0.00104342"/>
+			</inertial>
+		</link>
+
+		<joint name="${prefix}forearm_fixed" type="fixed">
+			<origin xyz="0 -0.09217 0" rpy="0 0 0"/>
+			<parent link="${prefix}forearm"/>
+			<child link="${prefix}wrist_pitch_bracket"/>
+		</joint>
+
+		<link name="${prefix}wrist_pitch_bracket">
+			<inertial>
+				<origin xyz="0 -0.04112 0" rpy="0 0 0"/>
+				<mass value="0.50058"/>
+				<inertia
+					ixx="0.000580228" ixy="0.0" ixz="0.0"
+					iyy="0.000541503" iyz="0.0"
+					izz="0.000750977"/>
+			</inertial>
+		</link>
+
+		<!-- wrist pitch -->
+		<joint name="${prefix}wrist_pitch" type="revolute">
+			<hdt id="${motor_base_id + 5}" kmin="50" kmax="100" inertia="0.05"/>
+			<axis xyz="1 0 0"/>
+			<limit effort="60.0" lower="-1.5708" upper="1.5708" velocity="2.0944"/>
+			<origin xyz="0 -0.055 0" rpy="0 0 0"/>
+			<parent link="${prefix}wrist_pitch_bracket"/>
+			<child link="${prefix}wrist_motors"/>
+			<dynamics damping="0.7" friction="0.0"/>
+		</joint>
+
+		<transmission name="${prefix}tran6">
+			<type>transmission_interface/SimpleTransmission</type>
+			<joint name="${prefix}wrist_pitch">
+			</joint>
+			<actuator name="${prefix}motor6">
+				<hardwareInterface>EffortJointInterface</hardwareInterface>
+				<mechanicalReduction>1</mechanicalReduction>
+			</actuator>
+		</transmission>
+
+		<link name="${prefix}wrist_motors">
+			<collision>
+				<origin xyz="0 0 0" rpy="0 1.57079633 0"/>
+				<geometry>
+					<cylinder length="0.08" radius="0.05"/>
+				</geometry>
+			</collision>
+			<visual>
+				<origin xyz="0 0 0.0" rpy="0 1.57079633 0"/>
+				<geometry>
+					<cylinder length="0.08" radius="0.05"/>
+				</geometry>
+				<material name="${prefix}grey"/>
+			</visual>
+			<inertial>
+				<origin xyz="0 -0.03855 0" rpy="0 0 0"/>
+				<mass value="0.99934"/>
+				<inertia
+					ixx="0.001905243" ixy="0.0" ixz="0.0"
+					iyy="0.000474765" iyz="0.0"
+					izz="0.001905243"/>
+			</inertial>
+		</link>
+
+		<!-- wrist yaw -->
+		<joint name="${prefix}wrist_yaw" type="revolute">
+			<hdt id="${motor_base_id + 6}" kmin="50" kmax="100" inertia="0.05"/>
+			<axis xyz="0 0 1"/>
+			<limit effort="60.0" lower="-1.5708" upper="1.5708" velocity="2.0944"/>
+			<origin xyz="0 -0.0771 0" rpy="0 0 0"/>
+			<parent link="${prefix}wrist_motors"/>
+			<child link="${prefix}wrist_yaw_bracket"/>
+			<dynamics damping="0.7" friction="0.0"/>
+		</joint>
+
+		<transmission name="${prefix}tran7">
+			<type>transmission_interface/SimpleTransmission</type>
+			<joint name="${prefix}wrist_yaw">
+			</joint>
+			<actuator name="${prefix}motor7">
+				<hardwareInterface>EffortJointInterface</hardwareInterface>
+				<mechanicalReduction>1</mechanicalReduction>
+			</actuator>
+		</transmission>
+
+		<link name="${prefix}wrist_yaw_bracket">
+			<collision>
+				<origin xyz="0 0 0" rpy="0 0 0"/>
+				<geometry>
+					<cylinder length="0.08" radius="0.05"/>
+				</geometry>
+			</collision>
+			<visual>
+				<origin xyz="0 0 0.0" rpy="0 0 0"/>
+				<geometry>
+					<cylinder length="0.08" radius="0.05"/>
+				</geometry>
+				<material name="${prefix}black"/>
+			</visual>
+			<inertial>
+				<origin xyz="0 -0.01177 0" rpy="0 0 0"/>
+				<mass value="0.47608"/>
+				<inertia
+					ixx="0.000705091" ixy="0.0" ixz="0.0"
+					iyy="0.000537081" iyz="0.0"
+					izz="0.000534342"/>
+			</inertial>
+		</link>
+
+		<!-- palm -->
+		<joint name="${prefix}palm" type="fixed">
+			<origin xyz="0 -0.055 0" rpy="0 0 0"/>
+			<parent link="${prefix}wrist_yaw_bracket"/>
+			<child link="${prefix}palm"/>
+		</joint>
+
+		<xacro:hdt_7dof_hand_bbox prefix="${prefix}" motor_base_id="${motor_base_id}" reflect="${reflect}" left_only="${left_only}" right_only="${right_only}" />
+	</xacro:macro>
+</robot>
+


### PR DESCRIPTION
Its actually mostly cylinders.  This is a bounding box description of the HDT arms. We will ultimately switch away from visualizing this.

This pull request should be merged alongside the following

valor_perception/fix_self_filter valor_platforms/fix_self_filter valor_manipulation/moveit_self_filter hdt_7dof_description/add_bbox
